### PR TITLE
fix: upgrade Vite to 7.3.2 to patch security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "absent-asteroid",
+  "name": "diogenes-portfolio",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "absent-asteroid",
+      "name": "diogenes-portfolio",
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/react": "^5.0.2",
@@ -5160,9 +5160,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",


### PR DESCRIPTION
- CVE-2024-45811: server.fs.deny bypass via ?import&raw
- CVE-2026-39363: Arbitrary File Read via WebSocket
- GHSA-4w7w-66w2-5vf9: Path Traversal in Optimized Deps

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)